### PR TITLE
Add --below option

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Usage:
   git-semver [flags]
 
 Flags:
+      --below string    only look at tags below version
   -h, --help            help for git-semver
       --major           bump major version
       --minor           bump minor version

--- a/cmd/git-semver/root.go
+++ b/cmd/git-semver/root.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/softsense/git-semver/pkg/git"
+	"github.com/softsense/git-semver/pkg/semver"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -16,8 +17,17 @@ var rootCmd = &cobra.Command{
 	Short: "A tool for bumping semantic versions based on git tags.",
 	Long:  `A tool for bumping semantic versions based on git tags.`,
 	Run: func(cmd *cobra.Command, args []string) {
+		var below *semver.Version
+		if viper.GetString("below") != "" {
+			v, err := semver.Parse(viper.GetString("below"))
+			if err != nil {
+				log.Fatal(err)
+			}
+			below = &v
+		}
 		g, err := git.Open(viper.GetString("repo"), git.Config{
 			Prefix: viper.GetString("prefix"),
+			Below:  below,
 		})
 		if err != nil {
 			log.Fatal(err)
@@ -60,6 +70,11 @@ func init() {
 
 	rootCmd.PersistentFlags().String("prefix", "", "use a prefix")
 	if err := viper.BindPFlag("prefix", rootCmd.PersistentFlags().Lookup("prefix")); err != nil {
+		log.Fatal(err)
+	}
+
+	rootCmd.PersistentFlags().String("below", "", "only look at tags below version")
+	if err := viper.BindPFlag("below", rootCmd.PersistentFlags().Lookup("below")); err != nil {
 		log.Fatal(err)
 	}
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -167,6 +167,10 @@ func (g *Git) History(prefix string) (string, error) {
 	return strings.Join(out, ""), nil
 }
 
+func (g *Git) Highest() semver.Version {
+	return g.highest
+}
+
 func parseTagRef(t string) (semver.Version, error) {
 	s := strings.Replace(t, "refs/tags/", "", 1)
 	v, err := semver.Parse(s)

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -14,6 +14,9 @@ import (
 type Config struct {
 	// Prefix to add to version strings
 	Prefix string
+
+	// Only look at tags below version
+	Below *semver.Version
 }
 
 type Git struct {
@@ -59,6 +62,9 @@ func Open(path string, cfg Config) (*Git, error) {
 		}
 
 		if len(n.Pre) > 0 {
+			return nil
+		}
+		if cfg.Below != nil && n.GTE(*cfg.Below) {
 			return nil
 		}
 		if n.GT(highest) {

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/mholt/archiver"
+	"github.com/softsense/git-semver/pkg/semver"
 	"github.com/stretchr/testify/require"
 )
 
@@ -37,6 +38,41 @@ func TestOpen(t *testing.T) {
 	t.Log("\n" + n.String())
 
 	require.Equal(t, "v0.0.3", n.String())
+}
+
+func TestBelow(t *testing.T) {
+	tests := []struct {
+		name   string
+		below  semver.Version
+		expect semver.Version
+	}{
+		{
+			name:   "higher",
+			below:  semver.MustParse("v9.9.9"),
+			expect: semver.MustParse("v0.0.2"),
+		},
+		{
+			name:   "same",
+			below:  semver.MustParse("v0.0.2"),
+			expect: semver.MustParse("v0.0.1"),
+		},
+		{
+			name:   "below",
+			below:  semver.MustParse("v0.0.1"),
+			expect: semver.MustParse("v0.0.0"),
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			g, err := Open("testdata/repo", Config{
+				Prefix: "v",
+				Below:  &test.below,
+			})
+			require.NoError(t, err)
+			require.Equal(t, test.expect, g.Highest())
+		})
+	}
 }
 
 func TestHistory(t *testing.T) {


### PR DESCRIPTION
This allows for specifying the highest version tag to take into account when finding the version to bump.
Example:
 If your latest version is v2.1.0 but you need to add a patch to the
 v1 branch of your project, you could run:
 `git-semver --prefix v --patch --below v2.0.0`
 Which would then give you a new version from the v1 tree:
 `v1.5.1` (if your previous v1 tag was `v1.5.0`)