### PR TITLE
Replace pkg/errors with stdlib errors

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/mholt/archiver v3.1.1+incompatible
 	github.com/nwaples/rardecode v1.1.0 // indirect
 	github.com/pierrec/lz4 v2.6.0+incompatible // indirect
-	github.com/pkg/errors v0.9.1
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/viper v1.7.1
 	github.com/stretchr/testify v1.3.0

--- a/go.sum
+++ b/go.sum
@@ -82,7 +82,6 @@ github.com/golang/snappy v0.0.3/go.mod h1:/XxbfmMg8lxefKM7IXC3fBNl/7bRcc72aCRzEW
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
-github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.5.5 h1:Khx7svrCpmxxtHBq5j2mp/xVjsi8hQMfNLvJFAlrGgU=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
@@ -139,7 +138,6 @@ github.com/klauspost/compress v1.4.1/go.mod h1:RyIbtBH6LamlWaDj8nUwkbUhJ87Yi3uG0
 github.com/klauspost/cpuid v1.2.0/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgoMS4s3ek=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/logfmt v0.0.0-20140226030751-b84e30acd515/go.mod h1:+0opPa2QZZtGFBFZlji/RkVcI2GknAs/DXo4wKdlNEc=
-github.com/kr/pretty v0.1.0 h1:L/CwN0zerZDmRFUapSPitk6f+Q3+0za1rQkzVuMiMFI=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
 github.com/kr/pretty v0.2.1 h1:Fmg33tUaq4/8ym9TJN1x7sLJnHVwhP33CNkpYV/7rwI=
 github.com/kr/pretty v0.2.1/go.mod h1:ipq/a2n7PKx3OHsz4KJII5eveXtPO4qwEXGdVfWzfnI=

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -28,7 +28,7 @@ type Git struct {
 func Open(path string, cfg Config) (*Git, error) {
 	r, err := git.PlainOpen(path)
 	if err != nil {
-		return nil, fmt.Errorf("failed to open git repo %s: %w", path, err)
+		return nil, fmt.Errorf("open git repo %s: %w", path, err)
 	}
 
 	var highest semver.Version
@@ -38,7 +38,7 @@ func Open(path string, cfg Config) (*Git, error) {
 
 	tagrefs, err := r.Tags()
 	if err != nil {
-		return nil, fmt.Errorf("failed to list tags: %w", err)
+		return nil, fmt.Errorf("list tags: %w", err)
 	}
 	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
 		n, err := parseTagRef(string(t.Name()))
@@ -73,7 +73,7 @@ func Open(path string, cfg Config) (*Git, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, fmt.Errorf("failed to loop over tags: %w", err)
+		return nil, fmt.Errorf("loop over tags: %w", err)
 	}
 
 	g := &Git{
@@ -88,35 +88,35 @@ func Open(path string, cfg Config) (*Git, error) {
 func (g *Git) Increment(major, minor, patch, dev bool) (semver.Version, error) {
 	newVersion, err := semver.Parse(g.highest.String())
 	if err != nil {
-		return semver.Version{}, fmt.Errorf("failed to create version: %w", err)
+		return semver.Version{}, fmt.Errorf("create version: %w", err)
 	}
 
 	if patch {
 		if err := newVersion.IncrementPatch(); err != nil {
-			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
+			return semver.Version{}, fmt.Errorf("increment: %w", err)
 		}
 	}
 
 	if minor {
 		if err := newVersion.IncrementMinor(); err != nil {
-			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
+			return semver.Version{}, fmt.Errorf("increment: %w", err)
 		}
 	}
 
 	if major {
 		if err := newVersion.IncrementMajor(); err != nil {
-			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
+			return semver.Version{}, fmt.Errorf("increment: %w", err)
 		}
 	}
 
 	if dev {
 		head, err := g.repo.Head()
 		if err != nil {
-			return semver.Version{}, fmt.Errorf("failed to get repo head: %w", err)
+			return semver.Version{}, fmt.Errorf("get repo head: %w", err)
 		}
 		snapshot, err := semver.NewPRVersion(fmt.Sprintf("snapshot-%s", head.Hash().String()[:7]))
 		if err != nil {
-			return semver.Version{}, fmt.Errorf("failed to build snapshot version: %w", err)
+			return semver.Version{}, fmt.Errorf("build snapshot version: %w", err)
 		}
 		newVersion.Pre = []semver.PRVersion{snapshot}
 	}
@@ -127,7 +127,7 @@ func (g *Git) Increment(major, minor, patch, dev bool) (semver.Version, error) {
 func (g *Git) History(prefix string) (string, error) {
 	head, err := g.repo.Head()
 	if err != nil {
-		return "", fmt.Errorf("failed to get head: %w", err)
+		return "", fmt.Errorf("get head: %w", err)
 	}
 
 	var prevHash *plumbing.Hash
@@ -137,7 +137,7 @@ func (g *Git) History(prefix string) (string, error) {
 	} else {
 		cIter, err := g.repo.Log(&git.LogOptions{From: prevRef.Hash()})
 		if err != nil {
-			return "", fmt.Errorf("failed to get log from %s: %w", prevRef.Hash(), err)
+			return "", fmt.Errorf("get log from %s: %w", prevRef.Hash(), err)
 		}
 		c, err := cIter.Next()
 		if err == nil {
@@ -147,7 +147,7 @@ func (g *Git) History(prefix string) (string, error) {
 
 	cIter, err := g.repo.Log(&git.LogOptions{From: head.Hash()})
 	if err != nil {
-		return "", fmt.Errorf("failed to get log from %s: %w", head.Hash(), err)
+		return "", fmt.Errorf("get log from %s: %w", head.Hash(), err)
 	}
 	out := make([]string, 0)
 	_ = cIter.ForEach(func(c *object.Commit) error {

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -1,10 +1,10 @@
 package git
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/softsense/git-semver/pkg/semver"
 	"gopkg.in/src-d/go-git.v4"
 	"gopkg.in/src-d/go-git.v4/plumbing"
@@ -28,7 +28,7 @@ type Git struct {
 func Open(path string, cfg Config) (*Git, error) {
 	r, err := git.PlainOpen(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to open git repo %s", path)
+		return nil, fmt.Errorf("failed to open git repo %s: %w", path, err)
 	}
 
 	var highest semver.Version
@@ -38,7 +38,7 @@ func Open(path string, cfg Config) (*Git, error) {
 
 	tagrefs, err := r.Tags()
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to list tags")
+		return nil, fmt.Errorf("failed to list tags: %w", err)
 	}
 	err = tagrefs.ForEach(func(t *plumbing.Reference) error {
 		n, err := parseTagRef(string(t.Name()))
@@ -73,7 +73,7 @@ func Open(path string, cfg Config) (*Git, error) {
 		return nil
 	})
 	if err != nil {
-		return nil, errors.Wrap(err, "failed to loop over tags")
+		return nil, fmt.Errorf("failed to loop over tags: %w", err)
 	}
 
 	g := &Git{
@@ -88,35 +88,35 @@ func Open(path string, cfg Config) (*Git, error) {
 func (g *Git) Increment(major, minor, patch, dev bool) (semver.Version, error) {
 	newVersion, err := semver.Parse(g.highest.String())
 	if err != nil {
-		return semver.Version{}, errors.Wrapf(err, "failed to create version")
+		return semver.Version{}, fmt.Errorf("failed to create version: %w", err)
 	}
 
 	if patch {
 		if err := newVersion.IncrementPatch(); err != nil {
-			return semver.Version{}, errors.Wrap(err, "failed to increment")
+			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
 		}
 	}
 
 	if minor {
 		if err := newVersion.IncrementMinor(); err != nil {
-			return semver.Version{}, errors.Wrap(err, "failed to increment")
+			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
 		}
 	}
 
 	if major {
 		if err := newVersion.IncrementMajor(); err != nil {
-			return semver.Version{}, errors.Wrap(err, "failed to increment")
+			return semver.Version{}, fmt.Errorf("failed to increment: %w", err)
 		}
 	}
 
 	if dev {
 		head, err := g.repo.Head()
 		if err != nil {
-			return semver.Version{}, errors.Wrap(err, "failed to get repo head")
+			return semver.Version{}, fmt.Errorf("failed to get repo head: %w", err)
 		}
 		snapshot, err := semver.NewPRVersion(fmt.Sprintf("snapshot-%s", head.Hash().String()[:7]))
 		if err != nil {
-			return semver.Version{}, errors.Wrap(err, "failed to build snapshot version")
+			return semver.Version{}, fmt.Errorf("failed to build snapshot version: %w", err)
 		}
 		newVersion.Pre = []semver.PRVersion{snapshot}
 	}
@@ -127,7 +127,7 @@ func (g *Git) Increment(major, minor, patch, dev bool) (semver.Version, error) {
 func (g *Git) History(prefix string) (string, error) {
 	head, err := g.repo.Head()
 	if err != nil {
-		return "", errors.Wrap(err, "failed to get head")
+		return "", fmt.Errorf("failed to get head: %w", err)
 	}
 
 	var prevHash *plumbing.Hash
@@ -137,7 +137,7 @@ func (g *Git) History(prefix string) (string, error) {
 	} else {
 		cIter, err := g.repo.Log(&git.LogOptions{From: prevRef.Hash()})
 		if err != nil {
-			return "", errors.Wrapf(err, "failed to get log from %s", prevRef.Hash())
+			return "", fmt.Errorf("failed to get log from %s: %w", prevRef.Hash(), err)
 		}
 		c, err := cIter.Next()
 		if err == nil {
@@ -147,7 +147,7 @@ func (g *Git) History(prefix string) (string, error) {
 
 	cIter, err := g.repo.Log(&git.LogOptions{From: head.Hash()})
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to get log from %s", head.Hash())
+		return "", fmt.Errorf("failed to get log from %s: %w", head.Hash(), err)
 	}
 	out := make([]string, 0)
 	_ = cIter.ForEach(func(c *object.Commit) error {


### PR DESCRIPTION
This PR replaces the deprecated [pkg/errors](https://github.com/pkg/errors) with stdlib `errors`, in particular making use of the error wrapping feature available since Go 1.13.

I've also updated all error messages to be more idiomatic. In particular, removing the `failed to` message which causes a lot of noise when wrapping errors.