### PR TITLE
add support for release candidate versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ Flags:
       --major           bump major version
       --minor           bump minor version
       --patch           bump patch version (default true)
+      --rc              bump rc version. will bump other version if an rc does
+                        not already exist.
       --repo string     path to git repository (default "./")
       --snapshot        set snapshot version
       --prefix string   use a prefix

--- a/cmd/git-semver/root.go
+++ b/cmd/git-semver/root.go
@@ -26,14 +26,15 @@ var rootCmd = &cobra.Command{
 			below = &v
 		}
 		g, err := git.Open(viper.GetString("repo"), git.Config{
-			Prefix: viper.GetString("prefix"),
-			Below:  below,
+			Prefix:    viper.GetString("prefix"),
+			Below:     below,
+			IncludeRC: viper.GetBool("rc"),
 		})
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		n, err := g.Increment(viper.GetBool("major"), viper.GetBool("minor"), viper.GetBool("patch"), viper.GetBool("snapshot"))
+		n, err := g.Increment(viper.GetBool("major"), viper.GetBool("minor"), viper.GetBool("patch"), viper.GetBool("snapshot"), viper.GetBool("rc"))
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -60,6 +61,11 @@ func init() {
 
 	rootCmd.Flags().Bool("patch", true, "bump patch version")
 	if err := viper.BindPFlag("patch", rootCmd.Flags().Lookup("patch")); err != nil {
+		log.Fatal(err)
+	}
+
+	rootCmd.Flags().Bool("rc", false, "bump rc version. will bump other version if an rc does not already exist.")
+	if err := viper.BindPFlag("rc", rootCmd.Flags().Lookup("rc")); err != nil {
 		log.Fatal(err)
 	}
 

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -34,7 +34,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	n, err := g.Increment(false, false, true, false)
+	n, err := g.Increment(false, false, true, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This PR adds support for creating and bumping Release Candidate versions.
It will check if there exists an rc version and if so bump that version number. Otherwise it will bump the version set by the other flags and then create an rc1 on that version.

v0.0.0 -> v0.0.1-rc1
v0.0.1-rc1 -> v0.0.1-rc2
v0.0.1 -> v0.0.2-rc1