### PR TITLE
fix compares of pre-release versions

### DIFF
--- a/pkg/semver/semver.go
+++ b/pkg/semver/semver.go
@@ -428,6 +428,10 @@ func (v PRVersion) Compare(o PRVersion) int {
 	} else { // both are Alphas
 		if v.VersionStr == o.VersionStr { //nolint
 			return 0
+		} else if len(v.VersionStr) > len(o.VersionStr) {
+			return 1
+		} else if len(v.VersionStr) < len(o.VersionStr) {
+			return -1
 		} else if v.VersionStr > o.VersionStr {
 			return 1
 		} else {


### PR DESCRIPTION
When comparing pre-release versions if a version has more characters it will be considered a later version, e.g. previously:
```
v1.2.0-rc9 > v1.2.0-rc10
```
Now
```
v1.2.0-rc9 < v1.2.0-rc10
```