### PR TITLE
disable CGO when building release asset

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -16,6 +16,8 @@ jobs:
           go-version: "1.21"
       - name: "Build git-semver"
         run: go build -o git-semver ./cmd/git-semver
+        env:
+          CGO_ENABLED: "0"
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1.0.0
@@ -37,4 +39,3 @@ jobs:
           asset_path: ./git-semver
           asset_name: git-semver
           asset_content_type: application/octet-stream
-


### PR DESCRIPTION
Got a report that the latest release failed with error:
```
git-semver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by git-semver)
git-semver: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by git-semver
```
Setting `CGO_ENABLED=0` for `go build` should fix that.