### PR TITLE
Set build version

### DIFF
--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -15,7 +15,7 @@ jobs:
         with:
           go-version: "1.21"
       - name: "Build git-semver"
-        run: go build -o git-semver ./cmd/git-semver
+        run: go build -o git-semver -ldflags "-X main.Version=${{ github.ref }}" ./cmd/git-semver
         env:
           CGO_ENABLED: "0"
       - name: Create Release


### PR DESCRIPTION
In order for `git-semver version` to work properly we need to inject the version number during build of the Go binary.