### PR TITLE
Update lint config

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,27 +1,25 @@
 linters:
   enable:
     # default
+    - gosimple
     - govet
+    - ineffassign
     - staticcheck
     - unused
-    - gosimple
-    - structcheck
-    - varcheck
-    - ineffassign
-    - deadcode
-    - typecheck
     # added
-    - golint
+    - typecheck
     - stylecheck
     - unconvert
     - goconst
     - gofmt
-    - depguard
     - unparam
     - nakedret
     - prealloc
-    - exportloopref
+    - copyloopvar
     - gocritic
+    - revive
+    - gocyclo
+    - funlen
   disable:
     - errcheck
 
@@ -34,12 +32,14 @@ issues:
     - path: _test\.go
       linters:
         - goconst
+        - funlen
+
+  exclude-dirs:
+    - (^|/)vendor($|/)
+  exclude-dirs-use-default: false
 
 run:
   build-tags:
     - db
     - integration
   tests: true
-  skip-dirs-use-default: false
-  skip-dirs:
-    - (^|/)vendor($|/)


### PR DESCRIPTION
A lot of the linters in the config are pretty old and have since been deprecated or even removed. This PR updates the config to a more up-to-date set of linters.

```
WARN [config_reader] The configuration option `run.skip-dirs` is deprecated, please use `issues.exclude-dirs`. 
WARN [config_reader] The configuration option `run.skip-dirs-use-default` is deprecated, please use `issues.exclude-dirs-use-default`. 
WARN The linter 'varcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN The linter 'structcheck' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN The linter 'deadcode' is deprecated (since v1.49.0) due to: The owner seems to have abandoned the linter. Replaced by unused. 
WARN The linter 'exportloopref' is deprecated (since v1.60.2) due to: Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar. 
WARN The linter 'golint' is deprecated (since v1.41.0) due to: The repository of the linter has been archived by the owner. Replaced by revive. 
ERRO [linters_context] deadcode: This linter is fully inactivated: it will not produce any reports. 
ERRO [linters_context] golint: This linter is fully inactivated: it will not produce any reports. 
ERRO [linters_context] structcheck: This linter is fully inactivated: it will not produce any reports. 
ERRO [linters_context] varcheck: This linter is fully inactivated: it will not produce any reports. 
```